### PR TITLE
revert/simplify to only styled-components as peerDeps, update deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - 10
+  - 14
 script:
   - npm run lint
   - npm test

--- a/lib/components/FooterDiv.js
+++ b/lib/components/FooterDiv.js
@@ -1,4 +1,4 @@
-import styled from '../styled';
+import styled from 'styled-components';
 import { themedConfig } from '../config';
 var FooterDiv = styled('div')({
   color: function color(props) {

--- a/lib/components/HeaderDiv.js
+++ b/lib/components/HeaderDiv.js
@@ -1,4 +1,4 @@
-import styled from '../styled';
+import styled from 'styled-components';
 import { themedConfig } from '../config';
 var HeaderDiv = styled('div')({
   color: function color(props) {

--- a/lib/components/IconDiv.js
+++ b/lib/components/IconDiv.js
@@ -1,4 +1,4 @@
-import styled from '../styled';
+import styled from 'styled-components';
 import { themedConfig } from '../config';
 var IconDiv = styled('div')({
   fontSize: '0.7em',

--- a/lib/components/ValueDiv.js
+++ b/lib/components/ValueDiv.js
@@ -1,4 +1,4 @@
-import styled from '../styled';
+import styled from 'styled-components';
 var ValueDiv = styled('div')({
   letterSpacing: '-0.05em',
   fontSize: '2.6rem',

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   "homepage": "https://github.com/kkostov/react-calendar-icon#readme",
   "dependencies": {
     "prop-types": "^15.7.2",
-    "react": "^16.12.0",
-    "react-dom": "^16.12.0"
+    "react": ">=16",
+    "react-dom": ">=16"
   },
   "files": [
     "CODE_OF_CONDUCT.md",
@@ -69,12 +69,10 @@
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-uglify": "^6.0.4",
     "rollup-plugin-visualizer": "^3.3.1",
-    "styled-components": "^4.4.1",
-    "styled-jss": "^2.2.3"
+    "styled-components": "^5.3.0"
   },
   "peerDependencies": {
-    "styled-components": "^4.4.1",
-    "styled-jss": "^2.2.3"
+    "styled-components": ">=4"
   },
   "bundlesize": [
     {

--- a/src/components/FooterDiv.js
+++ b/src/components/FooterDiv.js
@@ -1,4 +1,4 @@
-import styled from '../styled'
+import styled from 'styled-components'
 import { themedConfig } from '../config'
 
 const FooterDiv = styled('div')({

--- a/src/components/HeaderDiv.js
+++ b/src/components/HeaderDiv.js
@@ -1,4 +1,4 @@
-import styled from '../styled'
+import styled from 'styled-components'
 import { themedConfig } from '../config'
 
 const HeaderDiv = styled('div')({

--- a/src/components/IconDiv.js
+++ b/src/components/IconDiv.js
@@ -1,4 +1,4 @@
-import styled from '../styled'
+import styled from 'styled-components'
 import { themedConfig } from '../config'
 
 const IconDiv = styled('div')({

--- a/src/components/ValueDiv.js
+++ b/src/components/ValueDiv.js
@@ -1,4 +1,4 @@
-import styled from '../styled'
+import styled from 'styled-components'
 
 const ValueDiv = styled('div')({
   letterSpacing: '-0.05em',

--- a/src/styled.js
+++ b/src/styled.js
@@ -1,9 +1,0 @@
-try {
-  module.exports = require('styled-components').default
-} catch (e) {
-  try {
-    module.exports = require('styled-jss').default
-  } catch (e) {
-    throw new Error('Either styled-components or styled-jss must be installed')
-  }
-}


### PR DESCRIPTION
@kkostov Hey

I removed styled-jss, because npm@7 now tries to install peerDeps, we could use optionalDependencies fields, but if we want to support muliple possible `styled` library (like @emotion/react, etc..) maybe a better path would be react-with-styles

for now I think it's simpler to revert the change I did, thanks